### PR TITLE
fix: error in IV initialization

### DIFF
--- a/app/src/main/java/com/otus/myapplication/crypto/Security.kt
+++ b/app/src/main/java/com/otus/myapplication/crypto/Security.kt
@@ -64,7 +64,7 @@ class Security {
 
     private fun getInitializationVector(): AlgorithmParameterSpec {
         val iv = ByteArray(GCM_IV_LENGTH)
-        FIXED_IV.copyInto(iv, 0, GCM_IV_LENGTH)
+        FIXED_IV.copyInto(destination = iv, destinationOffset = 0, startIndex = 0, endIndex = GCM_IV_LENGTH)
         return GCMParameterSpec(128, iv)
     }
 


### PR DESCRIPTION
Добрый день!

В `FIXED_IV.copyInto(destination = iv, destinationOffset = 0, startIndex = GCM_IV_LENGTH)` были перепутаны параметры, что приводило к тому, что копировались только последние 4 байта из `FIXED_IV` в `iv`, остальное в `iv` оставалось заполненным нулями:

```
До вызова: FIXED_IV.copyInto()

IV: 3134003223491201
FIXED_IV: 51, 49, 51, 52, 48, 48, 51, 50, 50, 51, 52, 57, 49, 50, 48, 49
iv: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

После вызова: FIXED_IV.copyInto()
iv AFTER COPY: 49, 50, 48, 49, 0, 0, 0, 0, 0, 0, 0, 0 // <= так быть не должно
```

В исправлнной версии:
```
iv AFTER COPY: 51, 49, 51, 52, 48, 48, 51, 50, 50, 51, 52, 57 // <= ожидаемы результат
```